### PR TITLE
Fix PHP version regression by restoring missing handler removal direc…

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,28 @@
+# PHP Configuration Fix - Task Progress
+
+## Steps to Complete
+
+- [x] **Step 1: Create New Branch**
+  - Create branch: blackboxai-php-config-fix
+  - Switch to new branch
+
+- [x] **Step 2: Update web.config File**
+  - Add missing `<remove name="php74_via_FastCGI" />` directive
+  - Add missing `<remove name="php_via_FastCGI" />` directive
+  - Update PHP handler path from v8.2 to v8.1
+  - Ensure proper handler order and XML syntax
+
+- [x] **Step 3: Validate Configuration**
+  - Review XML structure for errors
+  - Verify handler configuration consistency
+  - Confirm PHP 8.1 path is correct
+
+- [ ] **Step 4: Git Operations**
+  - Commit changes with descriptive message
+  - Push branch to remote repository
+  - Verify git status shows clean working tree
+
+## Issue Context
+- PHP version was upgraded to 8.1 but reverted due to missing handler removal directives
+- Need to restore `php74_via_FastCGI` and `php_via_FastCGI` remove statements
+- Update script processor path to use PHP 8.1 instead of 8.2

--- a/web.config
+++ b/web.config
@@ -116,8 +116,10 @@
 
         <!-- PHP Handler (for IIS with PHP) -->
         <handlers>
+            <remove name="php74_via_FastCGI" />
+            <remove name="php_via_FastCGI" />
             <remove name="PHP_via_FastCGI" />
-            <add name="PHP_via_FastCGI" path="*.php" verb="GET,HEAD,POST,PUT,DELETE" modules="FastCgiModule" scriptProcessor="C:\Program Files\PHP\v8.2\php-cgi.exe" resourceType="Either" requireAccess="Script" />
+            <add name="PHP_via_FastCGI" path="*.php" verb="GET,HEAD,POST,PUT,DELETE" modules="FastCgiModule" scriptProcessor="C:\Program Files\PHP\v8.1\php-cgi.exe" resourceType="Either" requireAccess="Script" />
         </handlers>
 
         <!-- Compression -->


### PR DESCRIPTION
…tives

- Add missing php74_via_FastCGI removal directive
- Add missing php_via_FastCGI removal directive
- Update PHP handler path from v8.2 to v8.1
- Prevent interference from legacy PHP handlers

Resolves issue where PHP version was downgraded after handler lines were removed from web.config file.